### PR TITLE
[bugs] 구슬개수변경에 따른 변수값 업데이트

### DIFF
--- a/OddOrEvenGame/OddOrEvenGame.xcodeproj/project.pbxproj
+++ b/OddOrEvenGame/OddOrEvenGame.xcodeproj/project.pbxproj
@@ -19,6 +19,11 @@
 		6F5E7F3A274FDECA0012AB8A /* gamestart.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 6F5E7F37274FDECA0012AB8A /* gamestart.mp3 */; };
 		6F5E7F3B274FDECA0012AB8A /* intro.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 6F5E7F38274FDECA0012AB8A /* intro.mp3 */; };
 		6FBB6BE4274FEE63006175DC /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBB6BE3274FEE63006175DC /* SettingViewController.swift */; };
+		6FF392F229AF9DD50076BD64 /* PlaygroundController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF392F129AF9DD50076BD64 /* PlaygroundController.swift */; };
+		6FF392F429AF9DE90076BD64 /* GameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF392F329AF9DE90076BD64 /* GameView.swift */; };
+		6FF392F629AF9DF40076BD64 /* FistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF392F529AF9DF40076BD64 /* FistView.swift */; };
+		6FF392F829AF9E040076BD64 /* GameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF392F729AF9E040076BD64 /* GameViewModel.swift */; };
+		6FF392FA29AF9E150076BD64 /* GameResultModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF392F929AF9E150076BD64 /* GameResultModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,6 +62,11 @@
 		6F5E7F37274FDECA0012AB8A /* gamestart.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; name = gamestart.mp3; path = ../../../resource/gamestart.mp3; sourceTree = "<group>"; };
 		6F5E7F38274FDECA0012AB8A /* intro.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; name = intro.mp3; path = ../../../resource/intro.mp3; sourceTree = "<group>"; };
 		6FBB6BE3274FEE63006175DC /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
+		6FF392F129AF9DD50076BD64 /* PlaygroundController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundController.swift; sourceTree = "<group>"; };
+		6FF392F329AF9DE90076BD64 /* GameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameView.swift; sourceTree = "<group>"; };
+		6FF392F529AF9DF40076BD64 /* FistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FistView.swift; sourceTree = "<group>"; };
+		6FF392F729AF9E040076BD64 /* GameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameViewModel.swift; sourceTree = "<group>"; };
+		6FF392F929AF9E150076BD64 /* GameResultModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameResultModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -108,6 +118,7 @@
 		6F5E7EFB274D349B0012AB8A /* OddOrEvenGame */ = {
 			isa = PBXGroup;
 			children = (
+				6FF392F029AF9D6D0076BD64 /* SnapKit */,
 				6F5E7EFC274D349B0012AB8A /* AppDelegate.swift */,
 				6F5E7EFE274D349B0012AB8A /* SceneDelegate.swift */,
 				6F5E7F00274D349B0012AB8A /* ViewController.swift */,
@@ -146,6 +157,18 @@
 				6F5E7F38274FDECA0012AB8A /* intro.mp3 */,
 			);
 			path = mp3;
+			sourceTree = "<group>";
+		};
+		6FF392F029AF9D6D0076BD64 /* SnapKit */ = {
+			isa = PBXGroup;
+			children = (
+				6FF392F129AF9DD50076BD64 /* PlaygroundController.swift */,
+				6FF392F329AF9DE90076BD64 /* GameView.swift */,
+				6FF392F529AF9DF40076BD64 /* FistView.swift */,
+				6FF392F729AF9E040076BD64 /* GameViewModel.swift */,
+				6FF392F929AF9E150076BD64 /* GameResultModel.swift */,
+			);
+			path = SnapKit;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -281,9 +304,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6FF392F629AF9DF40076BD64 /* FistView.swift in Sources */,
 				6F5E7F01274D349B0012AB8A /* ViewController.swift in Sources */,
+				6FF392F229AF9DD50076BD64 /* PlaygroundController.swift in Sources */,
 				6F5E7EFD274D349B0012AB8A /* AppDelegate.swift in Sources */,
+				6FF392F829AF9E040076BD64 /* GameViewModel.swift in Sources */,
 				6F5E7EFF274D349B0012AB8A /* SceneDelegate.swift in Sources */,
+				6FF392F429AF9DE90076BD64 /* GameView.swift in Sources */,
+				6FF392FA29AF9E150076BD64 /* GameResultModel.swift in Sources */,
 				6FBB6BE4274FEE63006175DC /* SettingViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/OddOrEvenGame/OddOrEvenGame/SnapKit/FistView.swift
+++ b/OddOrEvenGame/OddOrEvenGame/SnapKit/FistView.swift
@@ -1,0 +1,20 @@
+//
+//  FistView.swift
+//  OddOrEvenGame
+//
+//  Created by Dongju on 2023/03/01.
+//
+
+import UIKit
+
+class FistView: UIView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/OddOrEvenGame/OddOrEvenGame/SnapKit/GameResultModel.swift
+++ b/OddOrEvenGame/OddOrEvenGame/SnapKit/GameResultModel.swift
@@ -1,0 +1,8 @@
+//
+//  GameResultViewModel.swift
+//  OddOrEvenGame
+//
+//  Created by Dongju on 2023/03/01.
+//
+
+import Foundation

--- a/OddOrEvenGame/OddOrEvenGame/SnapKit/GameView.swift
+++ b/OddOrEvenGame/OddOrEvenGame/SnapKit/GameView.swift
@@ -1,0 +1,20 @@
+//
+//  GameView.swift
+//  OddOrEvenGame
+//
+//  Created by Dongju on 2023/03/01.
+//
+
+import UIKit
+
+class GameView: UIView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/OddOrEvenGame/OddOrEvenGame/SnapKit/GameViewModel.swift
+++ b/OddOrEvenGame/OddOrEvenGame/SnapKit/GameViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  GameViewModel.swift
+//  OddOrEvenGame
+//
+//  Created by Dongju on 2023/03/01.
+//
+
+import Foundation

--- a/OddOrEvenGame/OddOrEvenGame/SnapKit/PlaygroundController.swift
+++ b/OddOrEvenGame/OddOrEvenGame/SnapKit/PlaygroundController.swift
@@ -1,0 +1,29 @@
+//
+//  PlaygroundController.swift
+//  OddOrEvenGame
+//
+//  Created by Dongju on 2023/03/01.
+//
+
+import UIKit
+
+class PlaygroundController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/OddOrEvenGame/OddOrEvenGame/ViewController.swift
+++ b/OddOrEvenGame/OddOrEvenGame/ViewController.swift
@@ -183,6 +183,8 @@ class ViewController: UIViewController, SettingDelegate {
     func getBallsCount(ballsCount: Int) {
         self.userBallCountLbl.text = "\(ballsCount)"
         self.computerBallCountLbl.text = "\(ballsCount)"
+        self.userBallsCount = ballsCount
+        self.comBallsCount = ballsCount
     }
     
 }

--- a/OddOrEvenGame_SnapKit/OddOrEvenGame_SnapKit/snapkit/PlaygroundController.swift
+++ b/OddOrEvenGame_SnapKit/OddOrEvenGame_SnapKit/snapkit/PlaygroundController.swift
@@ -15,7 +15,7 @@ class PlaygroundController: UIViewController {
         $0.backgroundColor = .yellow
         $0.setTitleColor(.black, for: .normal)
         $0.setTitle("GAME START", for: .normal)
-        $0.addTarget(self, action: #selector(gameStartPressed), for: .touchUpInside)
+        $0.addTarget(PlaygroundController.self, action: #selector(gameStartPressed), for: .touchUpInside)
     }
     
     var gameView = GameView()


### PR DESCRIPTION
## 반영내용 
### 함수명 getBallsCount
수정내용 : 세팅화면에서 변경된 구슬의 갯수를 UI에만 반영되고 있던 이슈 수정
AS-IS
```
self.userBallCountLbl.text = "\(ballsCount)"
self.computerBallCountLbl.text = "\(ballsCount)"
```
T0-BE
```
self.userBallCountLbl.text = "\(ballsCount)"
self.computerBallCountLbl.text = "\(ballsCount)"
self.userBallsCount = ballsCount
self.comBallsCount = ballsCount
```